### PR TITLE
Updating FB_VRC_NO_FFO to pass the device name to FFO and bptm for displaying on PMPS screen

### DIFF
--- a/L2SIVacuum/POUs/Functions/Valves/FB_VRC_NO_FFO.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Valves/FB_VRC_NO_FFO.TcPOU
@@ -24,7 +24,7 @@ VAR
 	tBPTMtimeout:TON;
 	bptm: BeamParameterTransitionManager;  
 	FFO    :    FB_FastFault :=(
-        i_DevName := 'VGC',
+        i_DevName := i_sDevName,
         i_Desc := 'Fault occurs when the valve is not in safe state',
         i_TypeCode := 16#1010);
 	xMPS_OK:	BOOL; (*MPS Fast OK, is set when the Valve is Open*)
@@ -177,6 +177,7 @@ bptm(fbArbiter:=fbArbiter,
      i_xMoving:=bMoving,
      i_xDoneMoving:= bDone,
      stCurrentBeamParameters:=PMPS_GVL.stCurrentBeamParameters,
+     sDeviceName:=i_sDevName,
      q_xTransitionAuthorized=>);
 // Timeout
 tBPTMtimeout(IN:= bMoving AND NOT bptm.q_xTransitionAuthorized , PT:=T#1S);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
FB_VRC_NO_FFO does not display a device name in PMPS for diagnostic purposes. I'm passing i_sDevName to FFO and bptm to fix this.
<!--- Describe your changes in detail -->

## Motivation and Context
Devices that trigger the PMPS system should have their device name display for diagnostic.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This hasn't been tested yet. I need some direction/support on how to do this for library updates. This FB doesn't currently have unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
