### PR TITLE
MKS392 Missing M_SetBits

### DIFF
--- a/L2SIVacuum/POUs/Functions/Gauges/FB_MKS392.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Gauges/FB_MKS392.TcPOU
@@ -57,5 +57,26 @@ ACT_IO();
 ]]></ST>
       </Implementation>
     </Action>
+    <Method Name="M_SetBits" Id="{106bbbc2-0b06-42f6-904e-df5a4040a1c2}">
+      <Declaration><![CDATA[METHOD M_SetBits : BOOL
+VAR_INPUT
+    TermBits : UINT; // The terminal's maximum value in bits
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[This^.iTermBits := TermBits;]]></ST>
+      </Implementation>
+    </Method>
+    <LineIds Name="FB_MKS392">
+      <LineId Id="3" Count="28" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MKS392.ACT_IO">
+      <LineId Id="2" Count="1" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MKS392.M_SetBits">
+      <LineId Id="1" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/L2SIVacuum/POUs/Functions/Gauges/FB_MKS392.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Gauges/FB_MKS392.TcPOU
@@ -67,16 +67,5 @@ END_VAR
         <ST><![CDATA[This^.iTermBits := TermBits;]]></ST>
       </Implementation>
     </Method>
-    <LineIds Name="FB_MKS392">
-      <LineId Id="3" Count="28" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MKS392.ACT_IO">
-      <LineId Id="2" Count="1" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MKS392.M_SetBits">
-      <LineId Id="1" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
MKS392 gauges cannot have it's i_TermBits var accessed because it is missing the M_SetBits function. I have added this in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A new gauge in XCS needs the upper analog bit range set from 32767 to 30518 according to the manual for the EL3174-0002. Our FBs all have a function to set this as we cannot access it directly due to this being a var and not var_in.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've removed this so it didn't make it's way to a library release, but I created an instance of the function block in a POU and set the bits to a non-default value. I observed that it was successful. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
