### PR TITLE
MXM7 xPRESS_OK Fix

### DIFF
--- a/L2SIVacuum/POUs/Functions/Gauges/FB_MX7M.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Gauges/FB_MX7M.TcPOU
@@ -73,8 +73,8 @@ IF IG.q_xHV_DIS THEN
     ELSIF rV > cGaugeMaxV AND rV < cGaugeStartingV - cDeadbandV THEN
         IG.eState := OoR;
         IG.rPRESS := cDefaultP;
-	ELSIF rV = cGaugeMaxV THEN
-		IG.eState := Off;
+    ELSIF rV = cGaugeMaxV THEN
+        IG.eState := Off;
         IG.rPRESS := cDefaultP;
     ELSE
         IG.eState := PressInvalid;
@@ -265,38 +265,5 @@ END_VAR
         <ST><![CDATA[This^.iTermBits := TermBits;]]></ST>
       </Implementation>
     </Method>
-    <LineIds Name="FB_MX7M">
-      <LineId Id="3" Count="23" />
-      <LineId Id="75" Count="0" />
-      <LineId Id="77" Count="1" />
-      <LineId Id="27" Count="47" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MX7M.ACT_Logger">
-      <LineId Id="2" Count="32" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MX7M.ACT_Persistent">
-      <LineId Id="2" Count="38" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MX7M.ACT_Recover">
-      <LineId Id="2" Count="7" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MX7M.IO">
-      <LineId Id="2" Count="7" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MX7M.M_HVE">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MX7M.M_Recover">
-      <LineId Id="3" Count="1" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MX7M.M_SetBits">
-      <LineId Id="2" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/L2SIVacuum/POUs/Functions/Gauges/FB_MX7M.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Gauges/FB_MX7M.TcPOU
@@ -58,7 +58,7 @@ rPRESS := LREAL_TO_REAL(EXPT(10,((rV-cBaseV)/cSlope+LOG(cBaseP))));
 
 (*Set Guage State based on the Analog voltage*)
 IF IG.q_xHV_DIS THEN
-    IF rV >= cGaugeLowV AND rV <= cGaugeMaxV THEN
+    IF rV >= cGaugeLowV AND rV < cGaugeMaxV THEN
         IG.eState := Valid;
         IG.rPRESS := rPRESS;
     ELSIF rV < cGaugeLowV AND rV >= cGaugeMinV - cDeadbandV THEN
@@ -72,6 +72,9 @@ IF IG.q_xHV_DIS THEN
         IG.rPRESS := cDefaultP;
     ELSIF rV > cGaugeMaxV AND rV < cGaugeStartingV - cDeadbandV THEN
         IG.eState := OoR;
+        IG.rPRESS := cDefaultP;
+	ELSIF rV = cGaugeMaxV THEN
+		IG.eState := Off;
         IG.rPRESS := cDefaultP;
     ELSE
         IG.eState := PressInvalid;
@@ -262,5 +265,38 @@ END_VAR
         <ST><![CDATA[This^.iTermBits := TermBits;]]></ST>
       </Implementation>
     </Method>
+    <LineIds Name="FB_MX7M">
+      <LineId Id="3" Count="23" />
+      <LineId Id="75" Count="0" />
+      <LineId Id="77" Count="1" />
+      <LineId Id="27" Count="47" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MX7M.ACT_Logger">
+      <LineId Id="2" Count="32" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MX7M.ACT_Persistent">
+      <LineId Id="2" Count="38" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MX7M.ACT_Recover">
+      <LineId Id="2" Count="7" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MX7M.IO">
+      <LineId Id="2" Count="7" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MX7M.M_HVE">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MX7M.M_Recover">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MX7M.M_SetBits">
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changes estate conditional to check if rV = 10V while PLC is commanding the gauge ON. This will occur when the gauge reads its maximum (0.01 torr) or is set OFF locally. Now, the gauge estate will be set to OFF. 

We've determined this to be acceptable because the case where the gauge is reading it's maximum will never be attainable under normal circumstances since the pirani protection setpoint is 0.001 torr. Therefore, the gauge should turn off before reaching a rV of 10V. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There have been observations where Televac MXM7 is locally set to OFF, but would still report xPRESS_OK. We use this bit to interlock other devices, so we want to ensure that when the gauge is OFF (although the PLC may be commanding on) that it still reports OFF in the function block.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Still needs to be tested.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
