### PR TITLE
Kashiyama NeoDry G FB

### DIFF
--- a/L2SIVacuum/DUTs/Pumps/ST_KashiyamaDryPump.TcDUT
+++ b/L2SIVacuum/DUTs/Pumps/ST_KashiyamaDryPump.TcDUT
@@ -20,6 +20,13 @@ STRUCT
     io: i
     '}
     q_xLspdDo	: 	BOOL;
+	{attribute 'pytmc' := '
+    pv: REM_DO;
+    field: ZNAM FALSE;
+    field: ONAM TRUE;
+    io: i
+    '}
+    q_xRemoteDo	: 	BOOL;
 
 (* Input *)
 {attribute 'pytmc' := '

--- a/L2SIVacuum/DUTs/Pumps/ST_KashiyamaDryPump.TcDUT
+++ b/L2SIVacuum/DUTs/Pumps/ST_KashiyamaDryPump.TcDUT
@@ -79,6 +79,13 @@ STRUCT
     io: io
     '}
     xLspdSW     :   BOOL;
+    {attribute 'pytmc' := '
+    pv: REMOTE_SW;
+    field: ZNAM FALSE;
+    field: ONAM TRUE;
+    io: io
+    '}
+    xRemoteSW     :   BOOL;
     LowSP  :   REAL := 0.02; //Torr
     HighSP :   REAL; //Torr
     RdyTmr : REAL;

--- a/L2SIVacuum/DUTs/Pumps/ST_KashiyamaDryPump.TcDUT
+++ b/L2SIVacuum/DUTs/Pumps/ST_KashiyamaDryPump.TcDUT
@@ -20,7 +20,7 @@ STRUCT
     io: i
     '}
     q_xLspdDo	: 	BOOL;
-	{attribute 'pytmc' := '
+    {attribute 'pytmc' := '
     pv: REM_DO;
     field: ZNAM FALSE;
     field: ONAM TRUE;

--- a/L2SIVacuum/L2SIVacuum.plcproj
+++ b/L2SIVacuum/L2SIVacuum.plcproj
@@ -330,6 +330,9 @@
     <Compile Include="POUs\Functions\Pumps\FB_KashiyamaPump.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Functions\Pumps\FB_KashiyamaPump_G.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Functions\Pumps\FB_PIP_Gamma.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump.TcPOU
@@ -67,7 +67,7 @@ IF NOT q_stPump.i_xAlarmOK THEN
     q_stPump.eState := pumpFAULT;
 ELSIF NOT q_stPump.q_xRunDo AND q_stPump.i_xAlarmOK THEN
         q_stPump.eState := pumpSTOPPED;
-ELSIF NOT q_stPump.q_xRunDo AND NOT q_stPump.i_xIsRun THEN
+ELSIF q_stPump.q_xRunDo AND NOT q_stPump.i_xIsRun THEN
         q_stPump.eState := pumpSTARTING;
 ELSIF q_stPump.i_xIsRun THEN
         q_stPump.eState := pumpRUNNING;

--- a/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_KashiyamaPump_G" Id="{0b0502f2-0c6b-40fa-943b-64b4a6556c70}" SpecialFunc="None">
+    <Declaration><![CDATA[(* This function block does basic controls FOR the Kashiyama pump. Turns off pump
+in the event of errors/ warnings. Provides interlocking interface.*)
+FUNCTION_BLOCK FB_KashiyamaPump_G
+VAR_IN_OUT
+
+END_VAR
+VAR_INPUT
+
+END_VAR
+VAR_OUTPUT
+    {attribute 'pytmc' := 'pv:'}
+    q_stPump : ST_KashiyamaDryPump;
+END_VAR
+VAR
+    TONtmr : TON;
+    resetTmr : TON;
+
+    (* Output *)
+    q_xRunDO 	AT%Q*:	BOOL;
+    q_xResetDo	AT%Q*: 	BOOL;
+    q_xLspdDo	AT%Q*: 	BOOL;
+	q_xRemote 	AT%Q*:  BOOL;
+
+(* Input *)
+    i_xAlarm	AT%I*:	BOOL;
+    i_xIsRun	AT%I*:	BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[
+//Only run when commanded to be in remote and there is no alarm (this is a normally open alarm 0 = OK)
+q_stPump.xIlkOK := q_stPump.q_xRemoteDO AND NOT q_stPump.i_xAlarmOK;
+
+IF q_stPump.xIlkOK THEN
+    q_stPump.q_xRunDO := q_stPump.pv_xRunSW;
+    ELSE
+        q_stPump.PV_xRunSW := FALSE;
+        q_stPump.q_xRunDO := FALSE;
+END_IF
+
+q_stPump.xLspd_IlkENA := q_stPump.xIlkOK;
+
+IF q_stPump.xLspd_IlkENA THEN
+    q_stPump.q_xLspdDo := q_stPump.xLspdSW;
+    ELSE
+        q_stPump.xLspdSW := FALSE;
+        q_stPump.q_xLspdDo := FALSE;
+END_IF
+
+//resetTmr (In := iq_stPump.xResetSW, PT := T#2S);
+//IF resetTmr.Q THEN
+//	iq_stPump.xResetSW := FALSE;
+//END_IF
+
+q_stPump.q_xResetDo := NOT q_stPump.i_xIsRun AND q_stPump.xResetSW;
+
+//countdown Timer
+TONtmr (IN := q_stPump.i_xIsRun, PT := T#20S);
+q_stPump.RdyTmr := TO_REAL(TONtmr.PT) - TO_REAL(TONtmr.ET);
+
+(*State evaluation*)
+IF NOT q_stPump.i_xAlarmOK THEN
+    q_stPump.eState := pumpFAULT;
+ELSIF NOT q_stPump.q_xRunDo AND q_stPump.i_xAlarmOK THEN
+        q_stPump.eState := pumpSTOPPED;
+ELSIF NOT q_stPump.q_xRunDo AND NOT q_stPump.i_xIsRun THEN
+        q_stPump.eState := pumpSTARTING;
+ELSIF q_stPump.i_xIsRun THEN
+        q_stPump.eState := pumpRUNNING;
+ELSE
+    q_stPump.eState := pumpFAULT;
+END_IF
+
+//Mapping
+ACT_IO();]]></ST>
+    </Implementation>
+    <Action Name="ACT_IO" Id="{cd71f84a-24ec-4e3d-aa2b-f0d8498f54d0}">
+      <Implementation>
+        <ST><![CDATA[(* Output *)
+    q_xRunDO 	:= q_stPump.q_xRunDO;
+    q_xResetDo := q_stPump.q_xResetDo;
+    q_xLspdDo := q_stPump.q_xLspdDo;
+	q_xRemote := q_stPump.q_xRemoteDo;
+(* Input *)
+    q_stPump.i_xAlarmOK :=	i_xAlarm;
+    q_stPump.i_xIsRun :=	i_xIsRun;]]></ST>
+      </Implementation>
+    </Action>
+    <Method Name="M_Run" Id="{07262c3a-7667-4780-bcae-a56652bc1657}">
+      <Declaration><![CDATA[METHOD PUBLIC M_Run : BOOL
+VAR_INPUT
+    run:bool; // set to true to run, false to stop;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+this^.q_stPump.pv_xRunSW := run;]]></ST>
+      </Implementation>
+    </Method>
+    <LineIds Name="FB_KashiyamaPump_G">
+      <LineId Id="1" Count="45" />
+    </LineIds>
+    <LineIds Name="FB_KashiyamaPump_G.ACT_IO">
+      <LineId Id="1" Count="7" />
+    </LineIds>
+    <LineIds Name="FB_KashiyamaPump_G.M_Run">
+      <LineId Id="1" Count="1" />
+    </LineIds>
+  </POU>
+</TcPlcObject>

--- a/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
@@ -22,7 +22,7 @@ VAR
     q_xRunDO 	AT%Q*:	BOOL;
     q_xResetDo	AT%Q*: 	BOOL;
     q_xLspdDo	AT%Q*: 	BOOL;
-	q_xRemote 	AT%Q*:  BOOL;
+    q_xRemote 	AT%Q*:  BOOL;
 
 (* Input *)
     i_xAlarm	AT%I*:	BOOL;
@@ -62,9 +62,9 @@ TONtmr (IN := q_stPump.i_xIsRun, PT := T#20S);
 q_stPump.RdyTmr := TO_REAL(TONtmr.PT) - TO_REAL(TONtmr.ET);
 
 (*State evaluation*)
-IF NOT q_stPump.i_xAlarmOK THEN
+IF q_stPump.i_xAlarmOK THEN  // reminder this is normally closed (0 = no alarm | 1 = alarm)
     q_stPump.eState := pumpFAULT;
-ELSIF NOT q_stPump.q_xRunDo AND q_stPump.i_xAlarmOK THEN
+ELSIF NOT q_stPump.q_xRunDo AND NOT q_stPump.i_xAlarmOK THEN
         q_stPump.eState := pumpSTOPPED;
 ELSIF NOT q_stPump.q_xRunDo AND NOT q_stPump.i_xIsRun THEN
         q_stPump.eState := pumpSTARTING;
@@ -83,7 +83,7 @@ ACT_IO();]]></ST>
     q_xRunDO 	:= q_stPump.q_xRunDO;
     q_xResetDo := q_stPump.q_xResetDo;
     q_xLspdDo := q_stPump.q_xLspdDo;
-	q_xRemote := q_stPump.q_xRemoteDo;
+    q_xRemote := q_stPump.q_xRemoteDo;
 (* Input *)
     q_stPump.i_xAlarmOK :=	i_xAlarm;
     q_stPump.i_xIsRun :=	i_xIsRun;]]></ST>
@@ -100,14 +100,5 @@ END_VAR
 this^.q_stPump.pv_xRunSW := run;]]></ST>
       </Implementation>
     </Method>
-    <LineIds Name="FB_KashiyamaPump_G">
-      <LineId Id="1" Count="45" />
-    </LineIds>
-    <LineIds Name="FB_KashiyamaPump_G.ACT_IO">
-      <LineId Id="1" Count="7" />
-    </LineIds>
-    <LineIds Name="FB_KashiyamaPump_G.M_Run">
-      <LineId Id="1" Count="1" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
@@ -128,7 +128,7 @@ VAR_INPUT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[this^.q_stPump.q_xRemoteDo := remote;]]></ST>
+        <ST><![CDATA[this^.q_stPump.xRemoteSW := remote;]]></ST>
       </Implementation>
     </Method>
     <Method Name="M_Reset" Id="{67101dd4-d330-4e76-8840-ca74fe68dd48}">

--- a/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
@@ -66,7 +66,7 @@ IF q_stPump.i_xAlarmOK THEN  // reminder this is normally closed (0 = no alarm |
     q_stPump.eState := pumpFAULT;
 ELSIF NOT q_stPump.q_xRunDo AND NOT q_stPump.i_xAlarmOK THEN
         q_stPump.eState := pumpSTOPPED;
-ELSIF NOT q_stPump.q_xRunDo AND NOT q_stPump.i_xIsRun THEN
+ELSIF q_stPump.q_xRunDo AND NOT q_stPump.i_xIsRun THEN
         q_stPump.eState := pumpSTARTING;
 ELSIF q_stPump.i_xIsRun THEN
         q_stPump.eState := pumpRUNNING;
@@ -118,7 +118,7 @@ VAR_INPUT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[this^.q_stPump.q_xLspdDo := lowspeed;]]></ST>
+        <ST><![CDATA[THIS^.q_stPump.xLspdSW := lowspeed;]]></ST>
       </Implementation>
     </Method>
     <Method Name="M_Remote" Id="{00e5798c-bdcc-4e95-88b6-b2d65e45e2c9}">
@@ -138,7 +138,7 @@ VAR_INPUT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[this^.q_stPump.q_xResetDo := reset;]]></ST>
+        <ST><![CDATA[this^.q_stPump.xResetSW := reset;]]></ST>
       </Implementation>
     </Method>
     <Method Name="M_Run" Id="{07262c3a-7667-4780-bcae-a56652bc1657}">

--- a/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
@@ -75,20 +75,72 @@ ELSE
 END_IF
 
 //Mapping
-ACT_IO();]]></ST>
+M_IO();]]></ST>
     </Implementation>
-    <Action Name="ACT_IO" Id="{cd71f84a-24ec-4e3d-aa2b-f0d8498f54d0}">
+    <Method Name="M_Alarm" Id="{7e55e378-9ab6-4983-add4-a4faf7232b2c}">
+      <Declaration><![CDATA[METHOD M_Alarm : BOOL
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[M_alarm := THIS^.q_stPump.i_xAlarmOK;   // 0 = no alarm | 1 = alarm ]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="M_IO" Id="{cc5a91ec-d268-412f-a580-fe0b22b2f643}">
+      <Declaration><![CDATA[METHOD M_IO : BOOL
+VAR_INPUT
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[(* Output *)
-    q_xRunDO 	:= q_stPump.q_xRunDO;
-    q_xResetDo := q_stPump.q_xResetDo;
-    q_xLspdDo := q_stPump.q_xLspdDo;
-    q_xRemote := q_stPump.q_xRemoteDo;
+    q_xRunDO 	:= THIS^.q_stPump.q_xRunDO;
+    q_xResetDo := THIS^.q_stPump.q_xResetDo;
+    q_xLspdDo := THIS^.q_stPump.q_xLspdDo;
+    q_xRemote := THIS^.q_stPump.q_xRemoteDo;
 (* Input *)
-    q_stPump.i_xAlarmOK :=	i_xAlarm;
-    q_stPump.i_xIsRun :=	i_xIsRun;]]></ST>
+    THIS^.q_stPump.i_xAlarmOK :=	THIS^.i_xAlarm;
+    THIS^.q_stPump.i_xIsRun :=	THIS^.i_xIsRun;]]></ST>
       </Implementation>
-    </Action>
+    </Method>
+    <Method Name="M_IsRun" Id="{1961f1b5-d27b-43e9-88c2-bcaabedd5a6a}">
+      <Declaration><![CDATA[METHOD M_IsRun : BOOL
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[M_IsRun := THIS^.q_stPump.i_xIsRun;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="M_Lspd" Id="{dbd5297e-2d54-4e99-84aa-49271fd6d365}">
+      <Declaration><![CDATA[METHOD M_Lspd : BOOL
+VAR_INPUT
+    lowspeed : BOOL;  // Set low speed setting
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[this^.q_stPump.q_xLspdDo := lowspeed;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="M_Remote" Id="{00e5798c-bdcc-4e95-88b6-b2d65e45e2c9}">
+      <Declaration><![CDATA[METHOD M_Remote : BOOL
+VAR_INPUT
+    remote : BOOL; // Remote command
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[this^.q_stPump.q_xRemoteDo := remote;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="M_Reset" Id="{67101dd4-d330-4e76-8840-ca74fe68dd48}">
+      <Declaration><![CDATA[METHOD M_Reset : BOOL
+VAR_INPUT
+    reset : BOOL; // Set true to clear faults
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[this^.q_stPump.q_xResetDo := reset;]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="M_Run" Id="{07262c3a-7667-4780-bcae-a56652bc1657}">
       <Declaration><![CDATA[METHOD PUBLIC M_Run : BOOL
 VAR_INPUT

--- a/L2SIVacuum/Version/Global_Version.TcGVL
+++ b/L2SIVacuum/Version/Global_Version.TcGVL
@@ -6,8 +6,8 @@
 {attribute 'linkalways'}
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
-	{attribute 'const_non_replaced'}
-	stLibVersion_LCLS_Vacuum : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+    {attribute 'const_non_replaced'}
+    stLibVersion_LCLS_Vacuum : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/L2SIVacuum/Version/Global_Version.TcGVL
+++ b/L2SIVacuum/Version/Global_Version.TcGVL
@@ -6,8 +6,8 @@
 {attribute 'linkalways'}
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
-    {attribute 'const_non_replaced'}
-    stLibVersion_LCLS_Vacuum : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+	{attribute 'const_non_replaced'}
+	stLibVersion_LCLS_Vacuum : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/L2SIVacuumLib.tsproj
+++ b/L2SIVacuumLib.tsproj
@@ -41,7 +41,7 @@
 			</SubItem>
 		</DataType>
 	</DataTypes>
-	<Project ProjectGUID="{8307B492-8F76-4774-8A19-E2DE13DD96C6}" TargetNetId="172.21.148.154.1.1" Target64Bit="true" ShowHideConfigurations="#x106">
+	<Project ProjectGUID="{8307B492-8F76-4774-8A19-E2DE13DD96C6}" TargetNetId="172.21.148.154.1.1" ShowHideConfigurations="#x106">
 		<System>
 			<Settings MaxCpus="4">
 				<Cpu CpuId="3"/>
@@ -59,7 +59,7 @@
 		</System>
 		<Plc>
 			<Project GUID="{19F43C40-AA59-45D4-A14D-CFB75472AEBC}" Name="L2SIVacuum" PrjFilePath="L2SIVacuum\L2SIVacuum.plcproj" TmcFilePath="L2SIVacuum\L2SIVacuum.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{B13BFE45-D6ED-A4DD-4D92-ACB171C86402}" TmcPath="L2SIVacuum\L2SIVacuum.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{3A135F93-72CE-44A7-A2DB-62A339DAB936}" TmcPath="L2SIVacuum\L2SIVacuum.tmc">
 					<Name>L2SIVacuum Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Vars VarGrpType="8" AreaNo="4">
@@ -79,7 +79,7 @@
 						<Var>
 							<Name>PMPS_GVL.BP_jsonDoc</Name>
 							<Type>SJsonValue</Type>
-							<BitSize>32</BitSize>
+							<BitSize>64</BitSize>
 							<InOut>7</InOut>
 						</Var>
 					</Vars>

--- a/L2SIVacuumLib.tsproj
+++ b/L2SIVacuumLib.tsproj
@@ -79,7 +79,6 @@
 						<Var>
 							<Name>PMPS_GVL.BP_jsonDoc</Name>
 							<Type>SJsonValue</Type>
-							<BitSize>64</BitSize>
 							<InOut>7</InOut>
 						</Var>
 					</Vars>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
New FB for the G-Series dry pump. Adds remote / local DO and also has a NC alarm bit, as opposed to NO. This changes the state if/else check. The low speed operation is also slightly different - it can be activated before starting up the pump.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
New SDL request for the NeoDry G-Series dry pump from Kashiyama.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes, in the makerspace.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
