### PR TITLE
Fix for FB_Kashiyama_G Remote Command

### DIFF
--- a/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_KashiyamaPump_G.TcPOU
@@ -30,7 +30,8 @@ VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[
+      <ST><![CDATA[q_stPump.q_xRemoteDo := q_stPump.xRemoteSW;
+
 //Only run when commanded to be in remote and there is no alarm (this is a normally open alarm 0 = OK)
 q_stPump.xIlkOK := q_stPump.q_xRemoteDO AND NOT q_stPump.i_xAlarmOK;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I missed a line in the previous PR (commit b686e0e) to set the remote DO setting via EPICS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users will interface with this device in the GUI, so we need to allow the remote/local setting to be set from EPICS. I failed to catch this during testing in the previous PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with my pcdsdevice (in my dev environment, yet to be merged) in PyQT.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
