### PR TITLE
FB_PTM_Pfeiffer Serial IO error bug fix

### DIFF
--- a/L2SIVacuum/POUs/Functions/Pumps/FB_PTM_Pfeiffer.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_PTM_Pfeiffer.TcPOU
@@ -223,7 +223,7 @@ END_IF
 
 IF st_Pfeiffer_RBK.sErrorCode_303 = '' THEN
     ;
-ELSIF st_Pfeiffer_RBK.sErrorCode_303 <> '000000' THEN
+ELSIF st_Pfeiffer_RBK.iErrorCode_303 <> 0 THEN
 iq_stPTM.i_xFault := TRUE;
 ELSE
 iq_stPTM.i_xFault := FALSE;
@@ -258,5 +258,35 @@ END_VAR
         <ST><![CDATA[iq_stPTM.rForelineSP := i_fForelinePressureSP;]]></ST>
       </Implementation>
     </Method>
+    <LineIds Name="FB_PTM_Pfeiffer">
+      <LineId Id="3" Count="55" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PTM_Pfeiffer.ACT_IO">
+      <LineId Id="2" Count="10" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PTM_Pfeiffer.ACT_Logger">
+      <LineId Id="2" Count="32" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PTM_Pfeiffer.ACT_Persistent">
+      <LineId Id="2" Count="16" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PTM_Pfeiffer.M_Run">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PTM_Pfeiffer.M_Serial_IO">
+      <LineId Id="3" Count="51" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PTM_Pfeiffer.M_SetBackingSP">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PTM_Pfeiffer.M_SetForelineSP">
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/L2SIVacuum/POUs/Functions/Pumps/FB_PTM_Pfeiffer.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Pumps/FB_PTM_Pfeiffer.TcPOU
@@ -258,35 +258,5 @@ END_VAR
         <ST><![CDATA[iq_stPTM.rForelineSP := i_fForelinePressureSP;]]></ST>
       </Implementation>
     </Method>
-    <LineIds Name="FB_PTM_Pfeiffer">
-      <LineId Id="3" Count="55" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_PTM_Pfeiffer.ACT_IO">
-      <LineId Id="2" Count="10" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_PTM_Pfeiffer.ACT_Logger">
-      <LineId Id="2" Count="32" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_PTM_Pfeiffer.ACT_Persistent">
-      <LineId Id="2" Count="16" />
-      <LineId Id="1" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_PTM_Pfeiffer.M_Run">
-      <LineId Id="3" Count="0" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_PTM_Pfeiffer.M_Serial_IO">
-      <LineId Id="3" Count="51" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_PTM_Pfeiffer.M_SetBackingSP">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_PTM_Pfeiffer.M_SetForelineSP">
-      <LineId Id="2" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/L2SIVacuumLib.tsproj
+++ b/L2SIVacuumLib.tsproj
@@ -41,7 +41,7 @@
 			</SubItem>
 		</DataType>
 	</DataTypes>
-	<Project ProjectGUID="{8307B492-8F76-4774-8A19-E2DE13DD96C6}" TargetNetId="172.21.148.154.1.1" ShowHideConfigurations="#x106">
+	<Project ProjectGUID="{8307B492-8F76-4774-8A19-E2DE13DD96C6}" TargetNetId="172.21.148.154.1.1" Target64Bit="true" ShowHideConfigurations="#x106">
 		<System>
 			<Settings MaxCpus="4">
 				<Cpu CpuId="3"/>
@@ -59,7 +59,7 @@
 		</System>
 		<Plc>
 			<Project GUID="{19F43C40-AA59-45D4-A14D-CFB75472AEBC}" Name="L2SIVacuum" PrjFilePath="L2SIVacuum\L2SIVacuum.plcproj" TmcFilePath="L2SIVacuum\L2SIVacuum.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{3A135F93-72CE-44A7-A2DB-62A339DAB936}" TmcPath="L2SIVacuum\L2SIVacuum.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{FB363140-3A32-B77B-D500-EA49CEF44FB4}" TmcPath="L2SIVacuum\L2SIVacuum.tmc">
 					<Name>L2SIVacuum Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Vars VarGrpType="8" AreaNo="4">
@@ -79,6 +79,7 @@
 						<Var>
 							<Name>PMPS_GVL.BP_jsonDoc</Name>
 							<Type>SJsonValue</Type>
+							<BitSize>32</BitSize>
 							<InOut>7</InOut>
 						</Var>
 					</Vars>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changing the serial IO mapping function in the FB_PTM_Pfieffer function block to use the integer representation of the serial interface's error code instead of the string representation. The string field is populated from both errors and warnings, so if there is a warning, the FB will interpret this as an error. 

The block of code below is where the serial driver writes to the warning and error fields. It is clear that we can differentiate between warnings and errors by using the integer representation instead. Note that we previously used `.sErrorCode_303` while I am proposing we use `.iErrorCode_303`
<img width="1465" height="730" alt="image" src="https://github.com/user-attachments/assets/a43efc8a-adf1-490c-9b76-6ca31d2fa08a" />

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
QRIX PTM-SC-30 has been throwing errors via the serial interface. After investigation, it was discovered that the issue was caused from repeated warning 007 (low power) as opposed to a fault/error. We do not want to stop the pump when there are warnings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with the problematic turbo. It successfully spins up without faulting.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
